### PR TITLE
New class .bio-photo for posts that requires multiple images with bio

### DIFF
--- a/wp-content/themes/Arduino/style.css
+++ b/wp-content/themes/Arduino/style.css
@@ -490,6 +490,12 @@ a.event span.date {
   position: relative;
 }
 
+.bio-photo {
+    width: 100%;
+    float: left;
+    margin-top: 20px;
+}
+
 .page-posts img{
   margin-top: 0%;
 }


### PR DESCRIPTION
New class **.bio-photo** for posts that requires multiple images with bio. 
<img width="540" alt="screen shot 2016-01-20 at 09 53 24" src="https://cloud.githubusercontent.com/assets/2944758/12443909/b0366ee4-bf5b-11e5-8f8c-82d2bb219210.png">
